### PR TITLE
DEPLOY-482 : Configure ActiveMQ to support Stomp

### DIFF
--- a/helm/activemq/Chart.yaml
+++ b/helm/activemq/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart Providing Apache ActiveMQ.
 name: activemq
-version: 0.1.0
+version: 0.1.1

--- a/helm/activemq/templates/deployment-activemq.yaml
+++ b/helm/activemq/templates/deployment-activemq.yaml
@@ -25,6 +25,8 @@ spec:
         - name: ACTIVEMQ_CONFIG_MAXMEMORY
           value: "{{ .Values.activemq.image.configMaxMemory }}"
         ports:
+        - name: stomp
+          containerPort: {{ .Values.activemq.services.broker.ports.internal.stomp | default 61613 }}
         - name: openwire
           containerPort: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61616 }}
         - name: amqp

--- a/helm/activemq/templates/svc-activemq-broker.yaml
+++ b/helm/activemq/templates/svc-activemq-broker.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   type: {{ .Values.activemq.services.broker.type }}
   ports:
-  - port: {{ .Values.activemq.services.broker.ports.external.openwire | default 61613 }}
-    targetPort: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61613 }}
+  - port: {{ .Values.activemq.services.broker.ports.external.stomp | default 61613 }}
+    targetPort: {{ .Values.activemq.services.broker.ports.internal.stomp | default 61613 }}
     name: stomp
     protocol: TCP
   - port: {{ .Values.activemq.services.broker.ports.external.openwire | default 61616 }}

--- a/helm/activemq/templates/svc-activemq-broker.yaml
+++ b/helm/activemq/templates/svc-activemq-broker.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   type: {{ .Values.activemq.services.broker.type }}
   ports:
+  - port: {{ .Values.activemq.services.broker.ports.external.openwire | default 61613 }}
+    targetPort: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61613 }}
+    name: stomp
+    protocol: TCP
   - port: {{ .Values.activemq.services.broker.ports.external.openwire | default 61616 }}
     targetPort: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61616 }}
     name: openwire

--- a/helm/activemq/values.yaml
+++ b/helm/activemq/values.yaml
@@ -14,11 +14,13 @@ activemq:
     broker:
       ports:
         internal:
+          stomp: 61613
           amqp: 5672
           openwire: 61616
         external:
+          stomp: 61613
           amqp: 5672
-          openwire: 61616        
+          openwire: 61616      
       name: activemq-broker
       type: ClusterIP
     webConsole:


### PR DESCRIPTION
Stomp is already configured in the image we use, I just opened up another port in the service for 61613.
These are the current URI's enabled:
`<transportConnectors>`
`<transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&wireFormat.maxFrameSize=104857600"/>`
`<transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&wireFormat.maxFrameSize=104857600"/>`
`<transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&wireFormat.maxFrameSize=104857600"/>`
`<transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&wireFormat.maxFrameSize=104857600"/>`
`<transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&wireFormat.maxFrameSize=104857600"/>`
`</transportConnectors>`