### PR TITLE
DEPLOY-509 Bump alfresco-identity-service to 0.3.0

### DIFF
--- a/helm/alfresco-infrastructure/requirements.yaml
+++ b/helm/alfresco-infrastructure/requirements.yaml
@@ -5,17 +5,17 @@ dependencies:
     condition: alfresco-infrastructure.rabbitmq-ha.enabled
   - name: activemq
     version: ^0.1.0
-    repository: http://kubernetes-charts.alfresco.com/incubator
+    repository: https://kubernetes-charts.alfresco.com/incubator
     condition: alfresco-infrastructure.activemq.enabled
   - name: alfresco-identity-service
-    version: ^0.2
+    version: ^0.3.0
     condition: alfresco-infrastructure.alfresco-identity-service.enabled
-    repository: http://kubernetes-charts.alfresco.com/incubator
+    repository: https://kubernetes-charts.alfresco.com/incubator
   - name: alfresco-activiti-cloud-registry
     version: ^0.1.0
     condition: alfresco-infrastructure.alfresco-activiti-cloud-registry.enabled
-    repository: http://kubernetes-charts.alfresco.com/incubator
+    repository: https://kubernetes-charts.alfresco.com/incubator
   - name: alfresco-api-gateway
     version: 0.1.1
     condition: alfresco-infrastructure.alfresco-api-gateway.enabled
-    repository: http://kubernetes-charts.alfresco.com/incubator
+    repository: https://kubernetes-charts.alfresco.com/incubator


### PR DESCRIPTION
Bringing in new identity service that contains Keycloak Stable version, and realm application has been changed.