### PR TITLE
REPO-3682 : Renditions: Deployment includes queue by default

### DIFF
--- a/helm/activemq/templates/deployment-activemq.yaml
+++ b/helm/activemq/templates/deployment-activemq.yaml
@@ -24,6 +24,12 @@ spec:
           value: "{{ .Values.activemq.image.configMinMemory }}"
         - name: ACTIVEMQ_CONFIG_MAXMEMORY
           value: "{{ .Values.activemq.image.configMaxMemory }}"
+        - name: ACTIVEMQ_BROKER_NAME
+          value: "{{ .Values.activemq.image.configBrokerName }}"
+        - name: ACTIVEMQ_ADMIN_LOGIN
+          value: "{{ .Values.activemq.image.configAdminLogin }}"
+        - name: ACTIVEMQ_ADMIN_PASSWORD	
+          value: "{{ .Values.activemq.image.configAdminPassword }}"
         ports:
         - name: stomp
           containerPort: {{ .Values.activemq.services.broker.ports.internal.stomp | default 61613 }}
@@ -36,13 +42,17 @@ spec:
         readinessProbe:
           tcpSocket:
             port: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61616 }}
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.activemq.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.activemq.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.activemq.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.activemq.readinessProbe.timeoutSeconds }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.activemq.services.broker.ports.internal.openwire | default 61616 }}
-          initialDelaySeconds: 5
-          periodSeconds: 25
+          initialDelaySeconds: {{ .Values.activemq.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.activemq.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.activemq.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.activemq.livenessProbe.timeoutSeconds }}
         volumeMounts:
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}

--- a/helm/activemq/values.yaml
+++ b/helm/activemq/values.yaml
@@ -1,10 +1,13 @@
 activemq:
   image:
-    repository: webcenter/activemq
-    tag: latest
+    repository: alfresco/alfresco-activemq
+    tag: 5.15.6-java-8-oracle-centos-7-ac5b98b35cd4
     pullPolicy: Always
     configMinMemory: "512"
     configMaxMemory: "2048"
+    configBrokerName : activemq-broker
+    configAdminLogin: admin
+    configAdminPassword: admin
   resources:
     requests:
       memory: "512Mi"
@@ -21,7 +24,7 @@ activemq:
           stomp: 61613
           amqp: 5672
           openwire: 61616      
-      name: activemq-broker
+      name: "{{ .Values.activemq.image.configBrokerName }}"
       type: ClusterIP
     webConsole:
       ports:
@@ -31,6 +34,18 @@ activemq:
           webConsole: 8161
       name: activemq-web-console
       type: NodePort
+  # The ActiveMQ readiness probe is used to check startup only as a failure
+  # of the liveness probe later will result in the pod being restarted.
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 6
+  livenessProbe:
+    initialDelaySeconds: 130
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 1
 
 persistence:
   existingClaim: "alfresco-volume-claim"


### PR DESCRIPTION
  - change activemq image to alfresco/alfresco-activemq
  - change liveliness and readiness probes
  - added properties for brokerName, adminLogin and adminPassword