### PR TITLE
Setup Custom Storage Class option

### DIFF
--- a/helm/alfresco-infrastructure/templates/pvc.yaml
+++ b/helm/alfresco-infrastructure/templates/pvc.yaml
@@ -26,12 +26,19 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: alfresco-volume-claim
-spec:
+spec:      
+  {{ if .Values.persistence.storageClass.enabled }}
   accessModes:
-  {{ if .Values.persistence.efs.enabled }}
+  {{- range .Values.persistence.storageClass.accessModes }}
+    - {{ . }}
+  {{- end }}
+  storageClassName: {{ .Values.persistence.storageClass.name }}
+  {{ else if .Values.persistence.efs.enabled }}
+  accessModes:
     - ReadWriteMany
   storageClassName: efs-{{ template "alfresco-infrastructure.fullname" . }}
   {{ else }}
+  accessModes:
     - ReadWriteOnce
   {{ end }}
   resources:

--- a/helm/alfresco-infrastructure/values.yaml
+++ b/helm/alfresco-infrastructure/values.yaml
@@ -1,6 +1,11 @@
 
 persistence:
   enabled: true
+  storageClass: #enable and define if you already have a custom storage class defined
+    enabled: false
+    accessModes:
+      - ReadWriteMany
+    name: "nfs-client" #Custom storage classs name
   efs:
     enabled: false
     dns: fs-example.efs.us-east-1.amazonaws.com #For aws you will need to specify the EFS server


### PR DESCRIPTION
We dont have any posibility of setting a custom storage class in our chart. That would be helpfull if a user has a predefined sc in his cluster. 
Or if we are using something like a nfs-client storage class set globally like we did to our cluster.